### PR TITLE
Make overridden setElement return Backbone.setElement's return value.

### DIFF
--- a/src/backbone.courier.js
+++ b/src/backbone.courier.js
@@ -136,8 +136,9 @@
 		// ****************** Overridden Backbone.View functions ****************** 
 
 		view.setElement = function( element, delegate ) {
-			overriddenViewMethods.setElement.call( this, element, delegate );
+			var retval = overriddenViewMethods.setElement.call( this, element, delegate );
 			prepareViewElement( view );
+			return retval;
 		};
 
 		// ****************** Body of Backbone.Courier.add() function ****************** 


### PR DESCRIPTION
When Backbone.Courier overrides Backbone.View's setElement, it's return value isn't propagated back to the caller.
