### PR TITLE
updated bower.json to support either 1.x or 2.x versions of jQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "backbone.courier",
 	"version": "0.6.2",
-	"homepage": "https://github.com/kinergy/backbone.courier",
+	"homepage": "https://github.com/rotundasoftware/backbone.courier",
 	"authors": [
 		"David Beck <david@rotundasoftware.com>"
 	],

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
 	"license": "MIT",
 	"dependencies" : {
 		"backbone" : "~1.1",
-		"jquery" : "~1.10"
+		"jquery" : "~1.11.1 || ~2.1.1"
 	}
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "backbone.courier",
-	"version": "0.5.10",
-	"homepage": "https://github.com/rotundasoftware/backbone.courier",
+	"version": "0.6.2",
+	"homepage": "https://github.com/kinergy/backbone.courier",
 	"authors": [
 		"David Beck <david@rotundasoftware.com>"
 	],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone-courier",
   "description": "Easily bubble events up your view hierarchy in your Backbone.js applications.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "src/backbone.courier.js",
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rotundasoftware/backbone.courier.git"
+    "url": "https://github.com/kinergy/backbone.courier.git"
   },
   "author": {
     "name": "Rotunda Software"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kinergy/backbone.courier.git"
+    "url": "https://github.com/rotundasoftware/backbone.courier.git"
   },
   "author": {
     "name": "Rotunda Software"


### PR DESCRIPTION
I have recently transitioned to jQuery v2.x and the current version of backbone.courier causes trouble when running `bower install` due to conflicting dependency versions for jQuery. I've updated your bower.json file to allow either jQuery 1.x or 2.x. Tests pass with 2.1.1, the current latest jQuery.