### PR TITLE
Fix Roundtrip messages for IE7

### DIFF
--- a/src/backbone.courier.js
+++ b/src/backbone.courier.js
@@ -39,7 +39,7 @@
 
 			this.trigger( message.name, message.data );
 
-			var isRoundTripMessage = message.name[ message.name.length - 1 ] === "!";
+			var isRoundTripMessage = message.name.charAt(message.name.length - 1) === "!";
 
 			var curParent = this._getParentView();
 			var messageShouldBePassed;


### PR DESCRIPTION
Problem with accessing to an individual character in a string. The bracket notation does not work in IE7 (it will return undefined)